### PR TITLE
Fix unused return value of apply_move

### DIFF
--- a/src/roar_net_api/algorithms/best_improvement.py
+++ b/src/roar_net_api/algorithms/best_improvement.py
@@ -43,7 +43,7 @@ def best_improvement(problem: _Problem[_TSolution], solution: _TSolution) -> _TS
 
         log.info(f"Best increment: {best_incr}")
 
-        best_move.apply_move(solution)
+        solution = best_move.apply_move(solution)
 
         move_iter = iter(_valid_moves_and_increments(neigh, solution))
         move_and_incr = next(move_iter, None)

--- a/src/roar_net_api/algorithms/first_improvement.py
+++ b/src/roar_net_api/algorithms/first_improvement.py
@@ -38,7 +38,7 @@ def first_improvement(problem: _Problem[_TSolution], solution: _TSolution) -> _T
 
         if increment < 0:
             log.info(f"Found increment: {increment}")
-            move.apply_move(solution)
+            solution = move.apply_move(solution)
             move_iter = iter(_valid_moves_and_increments(neigh, solution))
 
         move_and_incr = next(move_iter, None)

--- a/src/roar_net_api/algorithms/grasp.py
+++ b/src/roar_net_api/algorithms/grasp.py
@@ -71,7 +71,7 @@ def grasp(
             thresh = cmin + alpha * (cmax - cmin)
             rcl = [m for m, decr in cl if decr <= thresh]
             m = random.choice(rcl)
-            m.apply_move(s)
+            s = m.apply_move(s)
             obj = s.objective_value()
             if obj is not None and (bobj is None or obj < bobj):
                 b = s.copy_solution()

--- a/src/roar_net_api/algorithms/greedy_construction.py
+++ b/src/roar_net_api/algorithms/greedy_construction.py
@@ -55,7 +55,7 @@ def greedy_construction(problem: _Problem[_TSolution], solution: Optional[_TSolu
                 if incr == 0:
                     break
 
-        best_move.apply_move(solution)
+        solution = best_move.apply_move(solution)
 
         move_iter = iter(_valid_moves_and_increments(neigh, solution))
         move_and_incr = next(move_iter, None)
@@ -86,7 +86,7 @@ def greedy_construction_with_random_tie_breaking(
                 best_moves.append(move)
 
         log.info(f"Best increment: {best_incr}")
-        random.choice(best_moves).apply_move(solution)
+        solution = random.choice(best_moves).apply_move(solution)
 
         move_iter = iter(_valid_moves_and_increments(neigh, solution))
         move_and_incr = next(move_iter, None)

--- a/src/roar_net_api/algorithms/sa.py
+++ b/src/roar_net_api/algorithms/sa.py
@@ -80,7 +80,7 @@ def sa(
             assert incr is not None
 
             if acceptance(incr, t) >= random.random():
-                move.apply_move(solution)
+                solution = move.apply_move(solution)
                 obj = solution.objective_value()
                 assert obj is not None
 


### PR DESCRIPTION
In several algorithms the return value of `apply_move` was unused which would lead to issues for models that did not change the solution in place.